### PR TITLE
Explicitly specify location of include files

### DIFF
--- a/defensio-php/Defensio.php
+++ b/defensio-php/Defensio.php
@@ -10,8 +10,8 @@
  * @version 2.0
  *
  */
-require_once('lib/exceptions.php');
-require_once('lib/DefensioRestClient.php');
+require_once( dirname( __FILE__ ) . '/lib/exceptions.php' );
+require_once( dirname( __FILE__ ) . '/lib/DefensioRestClient.php' );
 
 class Defensio
 {

--- a/defensio-php/lib/DefensioRestClient.php
+++ b/defensio-php/lib/DefensioRestClient.php
@@ -1,5 +1,5 @@
 <?php
-require_once('exceptions.php');
+require_once( dirname( __FILE__ ) . '/exceptions.php' );
 
 class Defensio_REST_Client
 {


### PR DESCRIPTION
When the Defensio library is included from a third party script, we have no control over `include_path` or the current working directory, so it's better not to use relative include paths.
